### PR TITLE
req.query Fix

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -43,10 +43,10 @@ function factResponse(fact, req, res, num) {
   res.set("X-Numbers-API-Type", factObj.type);
   setExpireHeaders(res);
 
-  if (req.params.callback) {
+  if (req.query.callback) {
     // JSONP
     res.json(useJson ? factObj : factStr);
-  } else if (req.params.write !== undefined) {
+  } else if (req.query.write !== undefined) {
     var arg = useJson ? factObjStr() : '"' + _.escape(factStr) + '"';
     var script = "document.write(" + arg + ");";
     res.set("Content-Type", "text/javascript").send(script);
@@ -85,10 +85,10 @@ function factsResponse(fact, req, res, nums) {
 
   setExpireHeaders(res);
 
-  if (req.params.callback) {
+  if (req.query.callback) {
     // JSONP
     res.json(factsObj);
-  } else if (req.params.write !== undefined) {
+  } else if (req.query.write !== undefined) {
     var script = "document.write(" + factsObjStr() + ");";
     res.send(script, { "Content-Type": "text/javascript" }, 200);
   } else {

--- a/routes/api.js
+++ b/routes/api.js
@@ -90,9 +90,9 @@ function factsResponse(fact, req, res, nums) {
     res.json(factsObj);
   } else if (req.query.write !== undefined) {
     var script = "document.write(" + factsObjStr() + ");";
-    res.send(script, { "Content-Type": "text/javascript" }, 200);
+    res.status(200).set("Content-Type", "text/javascript").send(script);
   } else {
-    res.send(factsObjStr(), { "Content-Type": "application/json" }, 200);
+    res.status(200).set("Content-Type", "application/json").send(factsObjStr());
   }
 }
 


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Updated `req.params.write` => `req.query.write` to behave as specified in the README.md
- Updated `req.params.callback` => `req.query.callback` to behave as specified in the README.md
- Fixed `res.send()`. res.send() in Express.js V2 took 3 positional arguments, where res.send() in Express.js V4 does not.  

If this is related to an existing ticket, include a link to it as well.
fixes https://github.com/rithmschool/numbers_api/issues/20