### PR TITLE
add line to ignore sass-cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 secrets.js
 suggestions.json
 node_modules
+.sass-cache/


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

- Add ```.sass-cache/``` to the .gitignore file. This helps prevent tracking the .scssc files to git, after compiling by running ```compass compile public/```

If this is related to an existing ticket, include a link to it as well.
resolves #30 