### PR TITLE
Move secrets issue52

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+.env
 secrets.js
 suggestions.json
 node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *.pyc
 .env
-secrets.js
 suggestions.json
 node_modules
 .sass-cache/

--- a/app.js
+++ b/app.js
@@ -14,9 +14,9 @@ const mousewheel = require("jquery-mousewheel");
 
 const fact = require("./models/fact.js");
 const router = require("./routes/api.js");
-const secrets = require("./secrets.js");
 // const highcharts = require("./logs_highcharts.js");
 const utils = require("./public/js/shared_utils.js");
+require("dotenv").config();
 
 // fake number of viistors
 // var BASE_VISITOR_TIME = new Date(1330560000000);
@@ -30,11 +30,11 @@ const utils = require("./public/js/shared_utils.js");
 // var ADD_THIS_API_HOST = "api.addthis.com";
 // var ADD_THIS_API_SHARE_PATH =
 //   "/analytics/1.0/pub/shares.json?userid=" +
-//   secrets.ADD_THIS_USERNAME +
+//   process.env.ADD_THIS_USERNAME +
 //   "&password=" +
-//   secrets.ADD_THIS_PASSWORD +
+//   process.env.ADD_THIS_PASSWORD +
 //   "&pubid=" +
-//   secrets.ADD_THIS_PUBID;
+//   process.env.ADD_THIS_PUBID;
 // var GET_NUM_SHARES_INTERVAL_MS = 1000 * 30;
 var numShares = 15;
 // var arguments = process.argv.splice(2);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2251,6 +2251,11 @@
         }
       }
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "cors": "^2.8.5",
+    "dotenv": "^8.2.0",
     "errorhandler": "^1.5.1",
     "express": "^4.17.1",
     "forever": "^3.0.0",


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [ ] New number fact
- [ ] Translation
- [x] Refactor

The following changes were made

## -Move secrets to .env file

-Update dependencies to include dotenv
-Change app.js to use dotenv and process.env to access secrets
-Add .env to .gitignore
-Remove secrets.js requirement in app.js and .gitignore


Existing ticket:
https://github.com/rithmschool/numbers_api/issues/52