### PR TITLE
Create dummy data for testing

### DIFF
--- a/__tests__/integration/numbers.test.js
+++ b/__tests__/integration/numbers.test.js
@@ -117,23 +117,6 @@ describe("random routes", () => {
     jest.clearAllMocks();
   });
 
-  // tests for route "/random/:type?"
-  /**
- * [
-      '0',        'is',
-      'the',      'coldest',
-      'possible', 'temperature',
-      'old',      'the',
-      'Kelvin',   'scale.'
-    ]
-
- */
-
-  // 0 = -infinity
-  // 1 = infinity
-  // 2 = day -1
-  // 3 = day 0
-
   test("random with without type defined", async function () {
     const res = await request(app).get("/random");
     let resWords = res.text.split(" ");
@@ -142,9 +125,9 @@ describe("random routes", () => {
 
   test("random with type 'date'", async function () {
     const res = await request(app).get("/random/date");
-    let resWords = res.text.split(" ");
+    const date = res.text.slice(0, 11);
     expect(res.statusCode).toBe(200);
-    expect(resWords[0] + " " + resWords[1]).toEqual("January 1st");
+    expect(date).toEqual("January 1st");
   });
 
   test("random with type 'math'", async function () {
@@ -163,8 +146,8 @@ describe("random routes", () => {
 
   test("random with type 'year'", async function () {
     const res = await request(app).get("/random/year");
-    let resWords = res.text.split(" ");
+    let date = res.text.slice(0, 7);
     expect(res.statusCode).toBe(200);
-    expect(resWords[0] + " " + resWords[1]).toContain("1225 BC");
+    expect(date).toEqual("1225 BC");
   });
 });

--- a/__tests__/integration/numbers.test.js
+++ b/__tests__/integration/numbers.test.js
@@ -118,6 +118,21 @@ describe("random routes", () => {
   });
 
   // tests for route "/random/:type?"
+  /**
+ * [
+      '0',        'is',
+      'the',      'coldest',
+      'possible', 'temperature',
+      'old',      'the',
+      'Kelvin',   'scale.'
+    ]
+
+ */
+
+  // 0 = -infinity
+  // 1 = infinity
+  // 2 = day -1
+  // 3 = day 0
 
   test("random with without type defined", async function () {
     const res = await request(app).get("/random");

--- a/__tests__/unit/fact.test.js
+++ b/__tests__/unit/fact.test.js
@@ -10,17 +10,18 @@ const {
   dumpData,
   getDefaultMsg,
 } = require("../../models/fact");
+
 const fs = require("fs");
 
 describe("getRandomApiNum() with type 'date'", () => {
   test("return random number greater than or equal to 2010", function () {
     let greaterThanMin = getRandomApiNum({ min: 2010, type: "date" });
-    expect(greaterThanMin).toBeGreaterThan(2010);
+    expect(greaterThanMin).toBeGreaterThanOrEqual(2010);
   });
 
-  test("return random number less than 2010", function () {
+  test("return random number less than or equal to 2010", function () {
     let lessThanMax = getRandomApiNum({ max: 2010, type: "date" });
-    expect(lessThanMax).toBeLessThan(2010);
+    expect(lessThanMax).toBeLessThanOrEqual(2010);
   });
 
   test("return random number when min and max are NaN", function () {
@@ -35,14 +36,14 @@ describe("getRandomApiNum() with type 'date'", () => {
 });
 
 describe("getRandomApiNum() with type 'trivia'", () => {
-  test("return random number greater than 2010", function () {
+  test("return random number greater than or equal to 2010", function () {
     let greaterThanMin = getRandomApiNum({ min: 2010, type: "trivia" });
-    expect(greaterThanMin).toBeGreaterThan(2010);
+    expect(greaterThanMin).toBeGreaterThanOrEqual(2010);
   });
 
-  test("return random number less than 2010", function () {
+  test("return random number less than  or equal to 2010", function () {
     let lessThanMax = getRandomApiNum({ max: 2010, type: "trivia" });
-    expect(lessThanMax).toBeLessThan(2010);
+    expect(lessThanMax).toBeLessThanOrEqual(2010);
   });
 
   test("return random number when min and max are NaN", function () {
@@ -59,17 +60,18 @@ describe("getRandomApiNum() with type 'trivia'", () => {
 describe("getRandomApiNum() with type 'math'", () => {
   test("return same number as min and max", function () {
     let sameAsMinMax = getRandomApiNum({ min: 2010, max: 2010, type: "math" });
+
     expect(sameAsMinMax).toEqual(2010);
   });
 
-  test("return random number greater than 2010", function () {
+  test("return random number greater than  or equal to 2010", function () {
     let greaterThanMin = getRandomApiNum({ min: 2010, type: "math" });
-    expect(greaterThanMin).toBeGreaterThan(2010);
+    expect(greaterThanMin).toBeGreaterThanOrEqual(2010);
   });
 
-  test("return random number less than 2010", function () {
+  test("return random number less than  or equal to 2010", function () {
     let lessThanMax = getRandomApiNum({ max: 2010, type: "math" });
-    expect(lessThanMax).toBeLessThan(2010);
+    expect(lessThanMax).toBeLessThanOrEqual(2010);
   });
 
   test("return random number when min and max are NaN", function () {
@@ -89,14 +91,14 @@ describe("getRandomApiNum() with type 'year'", () => {
     expect(sameAsMinMax).toEqual(2010);
   });
 
-  test("return random number greater than 2010", function () {
+  test("return random number greater than  or equal to 2010", function () {
     let greaterThanMin = getRandomApiNum({ min: 2010, type: "year" });
-    expect(greaterThanMin).toBeGreaterThan(2009);
+    expect(greaterThanMin).toBeGreaterThanOrEqual(2010);
   });
 
-  test("return random number less than 2010", function () {
+  test("return random number less than  or equal to 2010", function () {
     let lessThanMax = getRandomApiNum({ max: 2010, type: "year" });
-    expect(lessThanMax).toBeLessThan(2010);
+    expect(lessThanMax).toBeLessThanOrEqual(2010);
   });
 
   test("return random number when min and max are NaN", function () {
@@ -442,16 +444,16 @@ describe("getFact()", () => {
 
 describe("getFactTexts", () => {
   test("returns correctly object with types and facts", function () {
-    let res = getFactTexts(["math", "trivia"], 0, 10);
+    let res = getFactTexts(["math", "trivia"], 0, 1);
 
-    expect(res["math"].length).toEqual(9);
-    expect(res["trivia"].length).toEqual(11);
+    expect(res["math"].length).toEqual(4);
+    expect(res["trivia"].length).toEqual(4);
   });
 });
 
 describe("getAllFacts(num)", () => {
   test("return all types of facts for given number", function () {
-    let validNum = getAllFacts(24);
+    let validNum = getAllFacts(1);
 
     expect(validNum.year.length).toBeGreaterThan(1);
     expect(validNum.date.length).toBeGreaterThan(1);
@@ -469,16 +471,6 @@ describe("getAllFacts(num)", () => {
     );
     expect(validNum.year[0]).toEqual(
       expect.stringContaining(
-        "Submit one at github.com/rithmschool/numbers_api"
-      )
-    );
-    expect(validNum.math[0]).toEqual(
-      expect.not.stringContaining(
-        "Submit one at github.com/rithmschool/numbers_api"
-      )
-    );
-    expect(validNum.date[0]).toEqual(
-      expect.not.stringContaining(
         "Submit one at github.com/rithmschool/numbers_api"
       )
     );

--- a/__tests__/unit/gqlQuery.test.js
+++ b/__tests__/unit/gqlQuery.test.js
@@ -3,19 +3,17 @@ const EasyGraphQLTester = require("easygraphql-tester");
 const { typeDefs } = require("../../graphql/schema/TypeDefs");
 const { schema } = require("../../graphql/schema/Schema");
 
-
 describe("Test getNumberFacts queries", () => {
   let tester;
 
   beforeEach(() => {
-
     tester = new EasyGraphQLTester(schema);
   });
 
   it("Should return the correct query result", async () => {
     const query = `
             {
-                getNumberFacts(number: 100) {
+                getNumberFacts(number: 1) {
                     trivia
                     math
                     year
@@ -27,9 +25,9 @@ describe("Test getNumberFacts queries", () => {
     result = result.data.getNumberFacts;
 
     expect(Object.keys(result).length).toEqual(3);
-    expect(result.trivia.length).toEqual(9);
-    expect(result.math.length).toEqual(5);
-    expect(result.year.length).toEqual(15);
+    expect(result.trivia.length).toEqual(4);
+    expect(result.math.length).toEqual(4);
+    expect(result.year.length).toEqual(4);
   });
 
   it("If number does not have fact, response includes default message ", async () => {
@@ -54,7 +52,7 @@ describe("Test getNumberFacts queries", () => {
   it("Result includes specific entry", async () => {
     const query = `
             {
-                getNumberFacts(number: 6) {
+                getNumberFacts(number: 2010) {
                     math
                 }
             }
@@ -63,7 +61,9 @@ describe("Test getNumberFacts queries", () => {
     result = result.data.getNumberFacts;
 
     expect(Object.keys(result).length).toEqual(1);
-    expect(result.math[0]).toEqual("the smallest perfect number");
+    expect(result.math[0]).toEqual(
+      "the number of trees on 15 vertices with diameter 7"
+    );
   });
 
   it("Should return the correct date for first leap year", async () => {
@@ -80,10 +80,12 @@ describe("Test getNumberFacts queries", () => {
 
     expect(result[0]).toEqual(expect.stringContaining("February 29th"));
     expect(result[0]).toEqual(
-        expect.not.stringContaining("Submit one at github.com/rithmschool/numbers_api")
+      expect.not.stringContaining(
+        "Submit one at github.com/rithmschool/numbers_api"
+      )
     );
     expect(result.length).toBeGreaterThan(1);
-  })
+  });
 
   it("Should return the correct date for negative numbers", async () => {
     const query = `
@@ -99,12 +101,14 @@ describe("Test getNumberFacts queries", () => {
 
     expect(result[0]).toEqual(expect.stringContaining("December 29th"));
     expect(result[0]).toEqual(
-        expect.not.stringContaining("Submit one at github.com/rithmschool/numbers_api")
+      expect.not.stringContaining(
+        "Submit one at github.com/rithmschool/numbers_api"
+      )
     );
     expect(result.length).toBeGreaterThan(1);
-  })
+  });
 
-  it("Should return the correct date for first leap year", async () => {
+  it("Should return the correct date for numbers past first year", async () => {
     const query = `
     {
         getNumberFacts(number: 4000) {
@@ -118,8 +122,10 @@ describe("Test getNumberFacts queries", () => {
 
     expect(result[0]).toEqual(expect.stringContaining("December 13th"));
     expect(result[0]).toEqual(
-        expect.not.stringContaining("Submit one at github.com/rithmschool/numbers_api")
+      expect.not.stringContaining(
+        "Submit one at github.com/rithmschool/numbers_api"
+      )
     );
     expect(result.length).toBeGreaterThan(1);
-  })
+  });
 });

--- a/models/dummyData.js
+++ b/models/dummyData.js
@@ -1,0 +1,117 @@
+let data = {
+  math: {
+    "1": [
+      { text: "the multiplicative identity", self: false, pos: "V" },
+      {
+        text:
+          "the first figurate number of every kind, such as triangular number, pentagonal number and centered hexagonal number, to name just a few",
+      },
+      {
+        text:
+          "also the first and second numbers in the Fibonacci sequence and is the first number in many other mathematical sequences",
+      },
+      {
+        text:
+          "the most common leading digit in many sets of data, a consequence of Benford's law",
+      },
+    ],
+    "2010": [
+      {
+        text: "the number of trees on 15 vertices with diameter 7",
+      },
+    ],
+    "0": [{ text: "0" }],
+  },
+  year: {
+    "1": [
+      {
+        text: "Amanishakheto, Queen of Kush (Nubia), dies",
+      },
+      {
+        text:
+          "the Teotihuacan culture in Mesoamerica begins (approximate date)",
+      },
+      {
+        text: "the poem Metamorphoses is written by Ovid",
+      },
+      {
+        text: "Livy writes his monumental History of Rome (Ab Urbe Condita)",
+      },
+    ],
+    "2010": [
+      {
+        date: "January 4",
+        text:
+          "the tallest man-made structure to date, the Burj Khalifa in Dubai, United Arab Emirates, is officially opened",
+      },
+      {
+        date: "January 8",
+        text:
+          "the Togo national football team is involved in an attack in Angola, and as a result withdraws from the Africa Cup of Nations",
+      },
+    ],
+    "0": [{ text: "0" }],
+    "-1225": [{ text: "stuff happened" }],
+  },
+  trivia: {
+    "1": [
+      { text: "the number of Gods in monotheism", manual: true },
+      {
+        text: "the number of dimensions of a line",
+      },
+      {
+        text: "the number of moons orbiting Earth",
+      },
+      { text: "the loneliest number" },
+    ],
+    "0": [{ text: "0" }],
+  },
+  date: {
+    "1": [
+      {
+        text: "the Julian calendar takes effect for the first time",
+      },
+      {
+        text: "the Roman Senate posthumously deifies Julius Caesar",
+      },
+      {
+        text:
+          "the Roman legions in Germania Superior refuse to swear loyalty to Galba",
+      },
+    ],
+    "60": [
+      {
+        text:
+          "Christopher Columbus uses his knowledge of a lunar eclipse that night to convince Native Americans to provide him with supplies",
+      },
+      {
+        text:
+          "February 29 is followed by February 30 in Sweden, in a move to abolish the Swedish calendar for a return to the Old style",
+      },
+    ],
+    "364": [
+      {
+        text:
+          "the USS Constitution under the command of Captain William Bainbridge, captures the HMS Java off the coast of Brazil after a three hour battle",
+      },
+      {
+        text:
+          "the Treaty of New Echota is signed, ceding all the lands of the Cherokee east of the Mississippi River to the United States",
+      },
+      {
+        text: "the first American YMCA opens in Boston, Massachusetts",
+      },
+    ],
+    "348": [
+      {
+        text: "is Taylor Swift's birthday in 1989",
+      },
+      {
+        text:
+          "in 1577 that Sir Francis Drake sets out from Plymouth, England, on his round-the-world voyage.",
+      },
+    ],
+  },
+};
+
+module.exports = data;

--- a/models/fact.js
+++ b/models/fact.js
@@ -1,7 +1,11 @@
 const _ = require("underscore");
-const data = require("./data.js");
+let data = require("./data.js");
+const testData = require("./dummyData.js");
 const utils = require("../public/js/shared_utils.js");
 const { type } = require("os");
+
+require("dotenv").config();
+data = process.env.NODE_ENV === "test" ? testData : data;
 
 /**
  *
@@ -159,6 +163,17 @@ const dataPairs = (function () {
   });
   return ret;
 })();
+
+// {
+//   data: [
+//     { number: -Infinity, string: '-Infinity' },
+//     { number: NaN, string: 'math' },
+//     { number: NaN, string: 'year' },
+//     { number: NaN, string: 'trivia' },
+//     { number: NaN, string: 'date' },
+//     { number: Infinity, string: 'Infinity' }
+//   ]
+// }
 
 // TODO: remove this, should be using dataPairs only. only reason this is here is because
 // _.sortedIndex() is working as expected. need to investigate

--- a/models/fact.js
+++ b/models/fact.js
@@ -164,17 +164,6 @@ const dataPairs = (function () {
   return ret;
 })();
 
-// {
-//   data: [
-//     { number: -Infinity, string: '-Infinity' },
-//     { number: NaN, string: 'math' },
-//     { number: NaN, string: 'year' },
-//     { number: NaN, string: 'trivia' },
-//     { number: NaN, string: 'date' },
-//     { number: Infinity, string: 'Infinity' }
-//   ]
-// }
-
 // TODO: remove this, should be using dataPairs only. only reason this is here is because
 // _.sortedIndex() is working as expected. need to investigate
 let dataKeys = {};


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] New number fact
- [ ] Translation

The following changes were made

## - Create dummy data for testing

- Create dummyData.js file in models folder that holds a small sub-set of database information
- Update fact.js to point to dummy data if NODE_ENV is "test" (`npm test` automatically sets NODE_ENV to "test")
- Update tests to reflect data inside dummy data file

Existing Ticket:
https://github.com/rithmschool/numbers_api/issues/84
