### PR TITLE
add docstrings for monthDaytoDayofYear() and dateToDayOfYear()

### DIFF
--- a/public/js/shared_utils.js
+++ b/public/js/shared_utils.js
@@ -57,6 +57,12 @@
     )}`;
   };
 
+  /** Takes in date object and converts it to the day number
+   *
+   * ex: Date object(Jan 1) -> 1
+   * ex: Dat object(Feb 1) -> 32
+   */
+
   const MONTH_DAYS = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
   exports.dateToDayOfYear = function (date) {
     let day = 0;
@@ -65,6 +71,13 @@
     }
     return day + date.getDate();
   };
+
+  /** Converts month and day into a date in 2004 (leap year)
+   * Uses dateToDayOfYear() helper function to get the day number in that year
+   *
+   * Input: month (number), day (number)
+   * Output: day number
+   */
 
   exports.monthDayToDayOfYear = function (month, day) {
     const date = new Date(2004, month - 1, day);
@@ -96,7 +109,6 @@
       } else {
         return `${number} is the year that`;
       }
-      
     }
   };
 


### PR DESCRIPTION
Resolves #102
This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [ ] New number fact
- [ ] Translation
- [ X ] Documentation

The following changes were made

## -
Added docstrings to `monthDaytoDayofYear()` and `dateToDayOfYear()` in shared-utils.js
-

If this is related to an existing ticket, include a link to it as well.
https://github.com/rithmschool/numbers_api/issues/102